### PR TITLE
add example with spatio-temporal search

### DIFF
--- a/source/search_context.adoc
+++ b/source/search_context.adoc
@@ -112,6 +112,55 @@ PyCSW opensearch only supports geographical searches querying for a box. For mor
 </csw:GetRecords>
 ----
 
+ * To find all datasets intersecting a polygon within a given time span:
+
+[source, xml]
+----
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<csw:GetRecords
+    xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
+    xmlns:gml="http://www.opengis.net/gml"
+    xmlns:ogc="http://www.opengis.net/ogc"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    service="CSW"
+    version="2.0.2"
+    resultType="results"
+    maxRecords="100"
+    outputFormat="application/xml"
+    outputSchema="http://www.opengis.net/cat/csw/2.0.2"
+    xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd" >
+  <csw:Query typeNames="csw:Record">
+    <csw:ElementSetName>summary</csw:ElementSetName>
+    <csw:Constraint version="1.1.0">
+      <ogc:Filter>
+        <ogc:And>
+          <ogc:Intersects>
+            <ogc:PropertyName>ows:BoundingBox</ogc:PropertyName>
+            <gml:Polygon>
+              <gml:exterior>
+                <gml:LinearRing>
+                  <gml:posList>
+                    63.3984 7.65173 60.7546 5.0449 59.0639 10.187 62.9065 12.4944 63.3984 7.65173
+                  </gml:posList>
+                </gml:LinearRing>
+              </gml:exterior>
+            </gml:Polygon>
+          </ogc:Intersects>
+          <ogc:PropertyIsGreaterThanOrEqualTo>
+            <ogc:PropertyName>apiso:TempExtent_begin</ogc:PropertyName>
+            <ogc:Literal>2022-03-01 00:00</ogc:Literal>
+          </ogc:PropertyIsGreaterThanOrEqualTo>
+          <ogc:PropertyIsLessThanOrEqualTo>
+            <ogc:PropertyName>apiso:TempExtent_end</ogc:PropertyName>
+            <ogc:Literal>2023-03-08 00:00</ogc:Literal>
+          </ogc:PropertyIsLessThanOrEqualTo>
+        </ogc:And>
+      </ogc:Filter>
+    </csw:Constraint>
+  </csw:Query>
+</csw:GetRecords>
+----
+
 * Then, you can query the CSW endpoint with, e.g., python:
 
 [source, python]


### PR DESCRIPTION
closes #94

just copy pasted the given example basically, 
I re-tested it by putting the xml into a file `xml_request_example_polygon_timew` and the with `requests.post('https://csw.s-enda.k8s.met.no', data=open("xml_request_example_polygon_timew").read()).text`